### PR TITLE
Fix temporary directory creation for Piwik >= 2.10 when fetching from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,10 @@ RUN apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 php
 RUN apt-get install -y php5-geoip php5 libgeoip-dev
 
 #Piwki
-RUN wget http://builds.piwik.org/latest.zip && \
-    unzip latest.zip && \
-    rm latest.zip
-RUN rm -rf /var/www/html && \
-    mv piwik /var/www/html
+RUN rm -fr /var/www/html && git clone --depth=1 https://github.com/piwik/piwik.git  /var/www/
+
+RUN mv /var/www/piwik /var/www/html
+    
 RUN chown -R www-data:www-data /var/www && \
     chmod -R 0755 /var/www/html/tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get install -y php5-geoip php5 libgeoip-dev
 RUN rm -fr /var/www/html && git clone --depth=1 https://github.com/piwik/piwik.git  /var/www/
 
 RUN mv /var/www/piwik /var/www/html
-    
+
+RUN mkdir /var/www/html/tmp
 RUN chown -R www-data:www-data /var/www && \
     chmod -R 0755 /var/www/html/tmp
 


### PR DESCRIPTION
Since Piwik 2.10 "tmp" directory is no longer in the source tree (also it is removed from ``latest.zip`` archive).

This PR adds explicit creation of ``/var/www/html/tmp``.

Based on PR #4 (fetching sources from git) by @vegasbrianc .
